### PR TITLE
feat(KUI-1286): add support for fallback to kth-style 9 cortina blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@kth/api-call": "^4.1.0",
         "@kth/kth-node-passport-oidc": "^5.1.0",
         "@kth/kth-node-response": "^1.0.7",
-        "@kth/kth-node-web-common": "^9.1.0",
+        "@kth/kth-node-web-common": "^9.2.0",
         "@kth/kth-reactstrap": "^0.4.78",
         "@kth/log": "^4.0.7",
         "@kth/monitor": "^4.2.1",
@@ -2940,16 +2940,16 @@
       "integrity": "sha512-iXRZLTSaIpuGEvZ7no9KUEp2+YATyuqdm72kglxGJCXRwIFhBDLRb9rHgUkuxu8fhhNtv8nH7F9v4Q2HhJL/cw=="
     },
     "node_modules/@kth/kth-node-web-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@kth/kth-node-web-common/-/kth-node-web-common-9.1.0.tgz",
-      "integrity": "sha512-zmsVvtlfwU+Jht0uYnKX+l+U0Pd6Vef8lKVa6YL5Q+FsKaeRGf0AgSnvPVnT8JxP0F/Zm6ax/sNbbeUJa7SQoQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@kth/kth-node-web-common/-/kth-node-web-common-9.2.0.tgz",
+      "integrity": "sha512-mjTPxreqwP1C/htWdJ63l9oHeTvJJjx70Z4qeYm1+DTEPZpEZK1tSEr+ZrmfIqiQHQM4sBGURaIwRqTmnd1vDg==",
       "dependencies": {
         "@kth/cortina-block": "^5.1.1",
         "@kth/log": "^4.0.7",
         "entities": "^2.2.0",
         "handlebars": "^4.7.8",
         "kth-node-i18n": "^1.0.18",
-        "kth-node-redis": "^3.2.0",
+        "kth-node-redis": "^3.3.0",
         "locale": "^0.1.0"
       }
     },
@@ -16904,16 +16904,16 @@
       "integrity": "sha512-iXRZLTSaIpuGEvZ7no9KUEp2+YATyuqdm72kglxGJCXRwIFhBDLRb9rHgUkuxu8fhhNtv8nH7F9v4Q2HhJL/cw=="
     },
     "@kth/kth-node-web-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@kth/kth-node-web-common/-/kth-node-web-common-9.1.0.tgz",
-      "integrity": "sha512-zmsVvtlfwU+Jht0uYnKX+l+U0Pd6Vef8lKVa6YL5Q+FsKaeRGf0AgSnvPVnT8JxP0F/Zm6ax/sNbbeUJa7SQoQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@kth/kth-node-web-common/-/kth-node-web-common-9.2.0.tgz",
+      "integrity": "sha512-mjTPxreqwP1C/htWdJ63l9oHeTvJJjx70Z4qeYm1+DTEPZpEZK1tSEr+ZrmfIqiQHQM4sBGURaIwRqTmnd1vDg==",
       "requires": {
         "@kth/cortina-block": "^5.1.1",
         "@kth/log": "^4.0.7",
         "entities": "^2.2.0",
         "handlebars": "^4.7.8",
         "kth-node-i18n": "^1.0.18",
-        "kth-node-redis": "^3.2.0",
+        "kth-node-redis": "^3.3.0",
         "locale": "^0.1.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@kth/api-call": "^4.1.0",
     "@kth/kth-node-passport-oidc": "^5.1.0",
     "@kth/kth-node-response": "^1.0.7",
-    "@kth/kth-node-web-common": "^9.1.0",
+    "@kth/kth-node-web-common": "^9.2.0",
     "@kth/kth-reactstrap": "^0.4.78",
     "@kth/log": "^4.0.7",
     "@kth/monitor": "^4.2.1",

--- a/server/server.js
+++ b/server/server.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/order */
 const server = require('@kth/server')
 
 // Now read the server config etc.
@@ -7,7 +8,7 @@ const AppRouter = require('kth-node-express-routing').PageRouter
 const { getPaths } = require('kth-node-express-routing')
 
 if (config.appInsights && config.appInsights.instrumentationKey) {
-  let appInsights = require('applicationinsights')
+  const appInsights = require('applicationinsights')
   appInsights
     .setup(config.appInsights.instrumentationKey)
     .setAutoDependencyCorrelation(true)
@@ -33,7 +34,7 @@ const _addProxy = uri => `${config.proxyPrefixPath.uri}${uri}`
 const log = require('@kth/log')
 const packageFile = require('../package.json')
 
-let logConfiguration = {
+const logConfiguration = {
   name: packageFile.name,
   app: packageFile.name,
   env: process.env.NODE_ENV,
@@ -73,6 +74,7 @@ require('./views/helpers')
  * ******************************
  */
 const accessLog = require('kth-node-access-log')
+
 server.use(accessLog(config.logging.accessLog))
 
 /* ****************************
@@ -86,7 +88,7 @@ const express = require('express')
 // Removes the "X-Powered-By: Express header" that shows the underlying Express framework
 server.disable('x-powered-by')
 
-/// Files/statics routes--
+// / Files/statics routes--
 
 const staticOption = { maxAge: 365 * 24 * 3600 * 1000 } // 365 days in ms is maximum
 
@@ -118,6 +120,7 @@ server.set('case sensitive routing', true)
  */
 const bodyParser = require('body-parser')
 const cookieParser = require('cookie-parser')
+
 server.use(bodyParser.json())
 server.use(bodyParser.urlencoded({ limit: '50mb', extended: true, parameterLimit: 1000000 }))
 server.use(cookieParser())
@@ -127,6 +130,7 @@ server.use(cookieParser())
  * ***********************
  */
 const session = require('@kth/session')
+
 const options = config.session
 options.sessionOptions.secret = config.sessionSecret
 server.use(session(options))
@@ -136,6 +140,7 @@ server.use(session(options))
  * ************************
  */
 const { languageHandler } = require('@kth/kth-node-web-common/lib/language')
+
 server.use(config.proxyPrefixPath.uri, languageHandler)
 
 /* ******************************
@@ -201,6 +206,7 @@ server.use(
     proxyPrefixPath: config.proxyPrefixPath.uri,
     hostUrl: config.hostUrl,
     redisConfig: config.cache.cortinaBlock.redis,
+    useStyle10: false,
   })
 )
 
@@ -223,6 +229,7 @@ server.use(
  */
 
 const fileUpload = require('express-fileupload')
+
 server.use(fileUpload())
 server.use(bodyParser.json({ limit: '50mb' }))
 server.use(bodyParser.urlencoded({ limit: '50mb', extended: true }))


### PR DESCRIPTION
- Upgrade @kth/kth-node-web-common to 9.2.0 that adds support for fallback to kth-style 9 Cortina blocks.
- eslint fixes