### PR TITLE
KUI-1492: update course round state logics

### DIFF
--- a/common-context/createCommonContextFunctions.js
+++ b/common-context/createCommonContextFunctions.js
@@ -50,19 +50,18 @@ const resolveUserAccessRights = (member, round, courseCode, semester) => {
 
 const groupLadokCourseRounds = ladokCourseRounds => {
   const groupedLadokCourseRounds = []
+
   ladokCourseRounds.forEach(round => {
-    if (groupedLadokCourseRounds.length > 0) {
-      groupedLadokCourseRounds.forEach(group => {
-        if (group.term == round.startperiod.inDigits) {
-          group.rounds.push(round)
-        } else {
-          groupedLadokCourseRounds.push({ term: round.startperiod.inDigits, rounds: [round] })
-        }
-      })
+    const term = round.startperiod.inDigits
+    const group = groupedLadokCourseRounds.find(g => g.term === term)
+
+    if (group) {
+      group.rounds.push(round)
     } else {
-      groupedLadokCourseRounds.push({ term: round.startperiod.inDigits, rounds: [round] })
+      groupedLadokCourseRounds.push({ term, rounds: [round] })
     }
   })
+
   return groupedLadokCourseRounds
 }
 
@@ -98,7 +97,6 @@ function handleCourseData(courseData, courseCode) {
         thisStore.roundAccess[term] = {}
       }
 
-      // TODO: Need to handle state somehow instead of just hardcoding it
       thisStore.roundData[term] = group.rounds.map(
         round =>
           (round.tillfalleskod = {
@@ -109,7 +107,8 @@ function handleCourseData(courseData, courseCode) {
             ladokUID: round.ladokUID,
             applicationCode: round.tillfalleskod,
             canBeAccessedByUser: resolveUserAccessRights(this.member, round, this.courseCode, term),
-            state: 'APPROVED',
+            status: round.status?.code,
+            isFull: round.fullsatt,
           })
       )
     })

--- a/common-context/createCommonContextFunctions.js
+++ b/common-context/createCommonContextFunctions.js
@@ -108,7 +108,7 @@ function handleCourseData(courseData, courseCode) {
             applicationCode: round.tillfalleskod,
             canBeAccessedByUser: resolveUserAccessRights(this.member, round, this.courseCode, term),
             status: round.status?.code,
-            isFull: round.fullsatt,
+            full: round.fullsatt,
           })
       )
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@kth/kth-reactstrap": "^0.4.78",
         "@kth/log": "^4.0.7",
         "@kth/monitor": "^4.3.1",
+        "@kth/om-kursen-ladok-client": "file:../studadm-om-kursen-packages/packages/om-kursen-ladok-client",
         "@kth/server": "^4.1.0",
         "@kth/session": "^3.0.9",
         "@kth/style": "^1.4.2",
@@ -41,7 +42,6 @@
         "kth-node-i18n": "^1.0.18",
         "kth-node-redis": "^3.3.0",
         "kth-style": "^10.3.3",
-        "om-kursen-ladok-client": "file:../studadm-om-kursen-packages/packages/om-kursen-ladok-client",
         "os": "^0.1.2",
         "passport": "^0.7.0",
         "prop-types": "^15.8.1",
@@ -95,10 +95,13 @@
       }
     },
     "../studadm-om-kursen-packages/packages/om-kursen-ladok-client": {
-      "version": "0.0.1",
+      "name": "@kth/om-kursen-ladok-client",
+      "version": "1.3.2",
       "dependencies": {
-        "ladok-attributvarde-utils": "file:../ladok-attributvarde-utils",
-        "ladok-mellanlager-client": "file:../ladok-mellanlager-client"
+        "@kth/ladok-attributvarde-utils": "file:../ladok-attributvarde-utils",
+        "@kth/ladok-mellanlager-client": "file:../ladok-mellanlager-client",
+        "date-fns": "^4.1.0",
+        "showdown": "^2.1.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2999,6 +3002,10 @@
       "dependencies": {
         "@kth/log": "^4.0.7"
       }
+    },
+    "node_modules/@kth/om-kursen-ladok-client": {
+      "resolved": "../studadm-om-kursen-packages/packages/om-kursen-ladok-client",
+      "link": true
     },
     "node_modules/@kth/server": {
       "version": "4.1.0",
@@ -11043,10 +11050,6 @@
         "node": "^10.13.0 || >=12.0.0"
       }
     },
-    "node_modules/om-kursen-ladok-client": {
-      "resolved": "../studadm-om-kursen-packages/packages/om-kursen-ladok-client",
-      "link": true
-    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "license": "MIT",
@@ -16369,6 +16372,15 @@
       "integrity": "sha512-RoBcUuL//5h69ocs6e0m/RGvyI/OTE2BBbXeGA5Xc5n4cwQBdoQqabz4UpXc/J2PlBzXaxPjVEP7bhD63sk8PQ==",
       "requires": {
         "@kth/log": "^4.0.7"
+      }
+    },
+    "@kth/om-kursen-ladok-client": {
+      "version": "file:../studadm-om-kursen-packages/packages/om-kursen-ladok-client",
+      "requires": {
+        "@kth/ladok-attributvarde-utils": "file:../ladok-attributvarde-utils",
+        "@kth/ladok-mellanlager-client": "file:../ladok-mellanlager-client",
+        "date-fns": "^4.1.0",
+        "showdown": "^2.1.0"
       }
     },
     "@kth/server": {
@@ -21965,13 +21977,6 @@
     },
     "oidc-token-hash": {
       "version": "5.0.1"
-    },
-    "om-kursen-ladok-client": {
-      "version": "file:../studadm-om-kursen-packages/packages/om-kursen-ladok-client",
-      "requires": {
-        "ladok-attributvarde-utils": "file:../ladok-attributvarde-utils",
-        "ladok-mellanlager-client": "file:../ladok-mellanlager-client"
-      }
     },
     "on-finished": {
       "version": "2.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@kth/kth-reactstrap": "^0.4.78",
         "@kth/log": "^4.0.7",
         "@kth/monitor": "^4.3.1",
-        "@kth/om-kursen-ladok-client": "file:../studadm-om-kursen-packages/packages/om-kursen-ladok-client",
+        "@kth/om-kursen-ladok-client": "^1.3.5",
         "@kth/server": "^4.1.0",
         "@kth/session": "^3.0.9",
         "@kth/style": "^1.4.2",
@@ -96,7 +96,7 @@
     },
     "../studadm-om-kursen-packages/packages/om-kursen-ladok-client": {
       "name": "@kth/om-kursen-ladok-client",
-      "version": "1.3.2",
+      "version": "1.3.5",
       "dependencies": {
         "@kth/ladok-attributvarde-utils": "file:../ladok-attributvarde-utils",
         "@kth/ladok-mellanlager-client": "file:../ladok-mellanlager-client",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "kth-node-i18n": "^1.0.18",
     "kth-node-redis": "^3.3.0",
     "kth-style": "^10.3.3",
-    "@kth/om-kursen-ladok-client": "file:../studadm-om-kursen-packages/packages/om-kursen-ladok-client",
+    "@kth/om-kursen-ladok-client": "^1.3.5",
     "os": "^0.1.2",
     "passport": "^0.7.0",
     "prop-types": "^15.8.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "kth-node-i18n": "^1.0.18",
     "kth-node-redis": "^3.3.0",
     "kth-style": "^10.3.3",
-    "om-kursen-ladok-client": "file:../studadm-om-kursen-packages/packages/om-kursen-ladok-client",
+    "@kth/om-kursen-ladok-client": "file:../studadm-om-kursen-packages/packages/om-kursen-ladok-client",
     "os": "^0.1.2",
     "passport": "^0.7.0",
     "prop-types": "^15.8.1",

--- a/public/js/app/components/MemoMenu.jsx
+++ b/public/js/app/components/MemoMenu.jsx
@@ -1,5 +1,6 @@
 import React, { useReducer } from 'react'
 import { Form, FormGroup, Label, Input } from 'reactstrap'
+import { EducationalInstanceStatus } from '@kth/om-kursen-ladok-client'
 import i18n from '../../../../i18n/index'
 import { SERVICE_URL } from '../util/constants'
 import Alert from '../components-shared/Alert'
@@ -197,7 +198,9 @@ function MemoMenu(props) {
                       const hasWebVersion = Object.keys(usedRoundsWithWebVer).includes(applicationCode) || false
                       const hasPublishedPdf = hasBeenUsed && !hasWebVersion
                       return (
-                        (round.state === 'APPROVED' || round.state === 'FULL') && (
+                        (round.status === EducationalInstanceStatus.Started ||
+                          round.status === EducationalInstanceStatus.Complete ||
+                          round.isFull) && (
                           <FormGroup className="form-check" key={applicationCode}>
                             <Input
                               type="checkbox"

--- a/public/js/app/components/MemoMenu.jsx
+++ b/public/js/app/components/MemoMenu.jsx
@@ -200,7 +200,7 @@ function MemoMenu(props) {
                       return (
                         (round.status === LadokStatusCode.Started ||
                           round.status === LadokStatusCode.Complete ||
-                          round.isFull) && (
+                          round.full) && (
                           <FormGroup className="form-check" key={applicationCode}>
                             <Input
                               type="checkbox"

--- a/public/js/app/components/MemoMenu.jsx
+++ b/public/js/app/components/MemoMenu.jsx
@@ -1,6 +1,6 @@
 import React, { useReducer } from 'react'
 import { Form, FormGroup, Label, Input } from 'reactstrap'
-import { EducationalInstanceStatus } from '@kth/om-kursen-ladok-client'
+import { LadokStatusCode } from '@kth/om-kursen-ladok-client'
 import i18n from '../../../../i18n/index'
 import { SERVICE_URL } from '../util/constants'
 import Alert from '../components-shared/Alert'
@@ -198,8 +198,8 @@ function MemoMenu(props) {
                       const hasWebVersion = Object.keys(usedRoundsWithWebVer).includes(applicationCode) || false
                       const hasPublishedPdf = hasBeenUsed && !hasWebVersion
                       return (
-                        (round.status === EducationalInstanceStatus.Started ||
-                          round.status === EducationalInstanceStatus.Complete ||
+                        (round.status === LadokStatusCode.Started ||
+                          round.status === LadokStatusCode.Complete ||
                           round.isFull) && (
                           <FormGroup className="form-check" key={applicationCode}>
                             <Input

--- a/server/apiCalls/ladokApi.js
+++ b/server/apiCalls/ladokApi.js
@@ -11,6 +11,8 @@ async function getLadokCourseData(courseCode, lang) {
 }
 
 async function getCourseRoundsData(courseCode, lang) {
+  // TODO: Add endpoint to ladok client for retieving data from previous year onward
+  // See requirements in https://kth-se.atlassian.net/browse/KUI-1492
   const previousYear = new Date().getFullYear() - 1
   const rounds = await client.getCourseRoundsFromPeriod(courseCode, `VT${previousYear}`, lang)
   return rounds

--- a/server/apiCalls/ladokApi.js
+++ b/server/apiCalls/ladokApi.js
@@ -11,8 +11,9 @@ async function getLadokCourseData(courseCode, lang) {
 }
 
 async function getCourseRoundsData(courseCode, lang) {
-  const course = await client.getAllCourseRounds(courseCode, lang)
-  return course
+  const previousYear = new Date().getFullYear() - 1
+  const rounds = await client.getCourseRoundsFromPeriod(courseCode, `VT${previousYear}`, lang)
+  return rounds
 }
 
 async function getCourseSchoolCode(courseCode) {

--- a/server/apiCalls/ladokApi.js
+++ b/server/apiCalls/ladokApi.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { createApiClient } = require('om-kursen-ladok-client')
+const { createApiClient } = require('@kth/om-kursen-ladok-client')
 const serverConfig = require('../configuration').server
 
 const client = createApiClient(serverConfig.ladokMellanlagerApi)
@@ -11,7 +11,7 @@ async function getLadokCourseData(courseCode, lang) {
 }
 
 async function getCourseRoundsData(courseCode, lang) {
-  const course = await client.getActiveCourseRounds(courseCode, lang)
+  const course = await client.getAllCourseRounds(courseCode, lang)
   return course
 }
 

--- a/test/mocks/mockWebContext.js
+++ b/test/mocks/mockWebContext.js
@@ -40,7 +40,7 @@ const mockWebContext = () => {
           startDate: '2019-08-26',
           targetGroup: [],
           status: 'S2',
-          isFull: true,
+          full: true,
         },
         {
           endDate: '2020-01-14',
@@ -52,7 +52,7 @@ const mockWebContext = () => {
           startDate: '2019-10-28',
           targetGroup: [],
           status: 'S3',
-          isFull: false,
+          full: false,
         },
       ],
       20201: [
@@ -66,7 +66,7 @@ const mockWebContext = () => {
           startDate: '2020-01-15',
           targetGroup: [],
           status: 'S2',
-          isFull: false,
+          full: false,
         },
         {
           endDate: '2020-06-01',
@@ -102,7 +102,7 @@ const mockWebContext = () => {
           startDate: '2020-10-26',
           targetGroup: [],
           status: 'S3',
-          isFull: true,
+          full: true,
         },
       ],
       20211: [

--- a/test/mocks/mockWebContext.js
+++ b/test/mocks/mockWebContext.js
@@ -39,7 +39,8 @@ const mockWebContext = () => {
           shortName: '',
           startDate: '2019-08-26',
           targetGroup: [],
-          state: 'APPROVED',
+          status: 'S2',
+          isFull: true,
         },
         {
           endDate: '2020-01-14',
@@ -50,7 +51,8 @@ const mockWebContext = () => {
           shortName: '',
           startDate: '2019-10-28',
           targetGroup: [],
-          state: 'APPROVED',
+          status: 'S3',
+          isFull: false,
         },
       ],
       20201: [
@@ -63,7 +65,8 @@ const mockWebContext = () => {
           shortName: '',
           startDate: '2020-01-15',
           targetGroup: [],
-          state: 'APPROVED',
+          status: 'S2',
+          isFull: false,
         },
         {
           endDate: '2020-06-01',
@@ -74,7 +77,7 @@ const mockWebContext = () => {
           shortName: '',
           startDate: '2020-03-16',
           targetGroup: [],
-          state: 'APPROVED',
+          status: 'S3',
         },
       ],
       20202: [
@@ -87,7 +90,7 @@ const mockWebContext = () => {
           shortName: '',
           startDate: '2020-08-24',
           targetGroup: [],
-          state: 'APPROVED',
+          status: 'S2',
         },
         {
           endDate: '2021-01-15',
@@ -98,7 +101,8 @@ const mockWebContext = () => {
           shortName: '',
           startDate: '2020-10-26',
           targetGroup: [],
-          state: 'APPROVED',
+          status: 'S3',
+          isFull: true,
         },
       ],
       20211: [
@@ -111,7 +115,7 @@ const mockWebContext = () => {
           shortName: '',
           startDate: '2021-01-18',
           targetGroup: [],
-          state: 'APPROVED',
+          status: 'S2',
         },
         {
           endDate: '2021-06-08',
@@ -121,7 +125,7 @@ const mockWebContext = () => {
           applicationCode: '1',
           shortName: '',
           startDate: '2021-03-22',
-          state: 'APPROVED',
+          status: 'S3',
         },
       ],
     },

--- a/test/unit/components/MemoMenu.test.js
+++ b/test/unit/components/MemoMenu.test.js
@@ -5,6 +5,13 @@ import userEvent from '@testing-library/user-event'
 import MemoMenu from '../../../public/js/app/components/MemoMenu'
 import mockWebContext from '../../mocks/mockWebContext'
 
+jest.mock('@kth/om-kursen-ladok-client', () => ({
+  LadokStatusCode: {
+    Started: 'S2',
+    Complete: 'S3',
+  },
+}))
+
 const RenderMemoMenu = ({ userLang = 'en', status = 'new', ...rest }) => {
   const rS = mockWebContext(userLang, status)
   return (


### PR DESCRIPTION
This PR contains updated round state logic using Ladok status codes and other attributes in `om-kursen-ladok-client` (https://github.com/KTH/studadm-om-kursen-packages/pull/66)

________________ 

Updated fetch of rounds according to requirement for `kurs-pm-data-admin-web`:

Användaren ska kunna välja bland samtliga terminer med minst ett kurstillfälle från året innan året för aktuellt datum och samtliga terminer med minst ett kurstillfälle efter det. (https://confluence.sys.kth.se/confluence/pages/viewpage.action?pageId=213359721)