### PR TITLE
fix(KUI-1969): fix authorization bug for course coordinators

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -245,7 +245,7 @@ appRoute.get(
   _addProxy('/:id'),
   oidc.login,
   requireRole(
-    'isCourseResponsible',
+    'isCourseCoordinator',
     'isExaminer',
     'isKursinfoAdmin',
     'isSuperUser',
@@ -258,7 +258,7 @@ appRoute.get(
   'system.gateway',
   _addProxy('/silent'),
   oidc.silentLogin,
-  requireRole('isCourseResponsible', 'isExaminer', 'isKursinfoAdmin', 'isSuperUser', 'isCourseTeacher'),
+  requireRole('isCourseCoordinator', 'isExaminer', 'isKursinfoAdmin', 'isSuperUser', 'isCourseTeacher'),
   Admin.getIndex
 )
 


### PR DESCRIPTION
Course coordinators can't access the admin page because of wrongly configured appRoutes. This is fixed now!