### PR TITLE
KUI-2039: fix bug where course title is [object Object]

### DIFF
--- a/common-context/createCommonContextFunctions.js
+++ b/common-context/createCommonContextFunctions.js
@@ -56,7 +56,7 @@ function handleCourseData(courseData, courseCode) {
       semesterObjectList: {},
     }
     this.courseTitle = {
-      name: benamning,
+      name: benamning.name,
       credits: omfattning,
     }
 


### PR DESCRIPTION
## 📌 Summary

<!-- Explain what this PR does and why. Link issues if relevant. -->

Fixes https://kth-se.atlassian.net/browse/KUI-2039

---

## 🔍 Changes

- Fetching course title using .benamning.name instead of .benamning

---

## ✅ Checklist (Author)

- [x] Code builds locally without errors
- [x] Tests added/updated and passing
- [x] Linting/formatting applied
- [x] No sensitive data in the diff
- [x] No stray console.logs in the diff
- [x] No stray comments in the diff
- [x] Docs/README/CHANGELOG updated (if needed)
- [x] Sufficient logging
- [x] Errors are handled accordingly

---

## 🧪 Testing & Verification

1. Made sure course title is no longer [object Object]
2. Ran test suite

Screenshots / recordings (if UI change):

---

## ⚠️ Impact / Risks

---

## 🚧 Out of Scope

---

## 📦 Downstream apps
